### PR TITLE
Update build instructions to align with IPC repo

### DIFF
--- a/quickstarts/deploy-a-subnet.md
+++ b/quickstarts/deploy-a-subnet.md
@@ -56,10 +56,8 @@ sudo usermod -aG docker $USER && newgrp docker
 
 # clone this repo and build
 git clone https://github.com/consensus-shipyard/ipc.git
-cd ipc/contracts
-make gen
-cd ..
-cargo build --release
+cd ipc
+make
 
 # building will generate the following binaries
 ./target/release/ipc-cli --version


### PR DESCRIPTION
This PR updates the IPC build instructions which were recently changed in the IPC repo  (see [PR](https://github.com/consensus-shipyard/ipc/pull/788/files))